### PR TITLE
perf(index)!: switch to callback style to remove Promise overhead

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,12 +13,14 @@ const CACHE_HEADERS = {
  * @author Frazer Smith
  * @description Simple plugin that adds an `onRequest` hook to disable client-side caching
  * by setting the relevant response headers.
- * @param {import("fastify").FastifyInstance} server - Fastify instance.
+ * @type {import("fastify").FastifyPluginCallback}
  */
-async function fastifyDisablecache(server) {
-	server.addHook("onRequest", async function setCacheHeaders(_req, res) {
+function fastifyDisablecache(server, _opts, done) {
+	server.addHook("onRequest", (_req, res, next) => {
 		res.headers(CACHE_HEADERS);
+		next();
 	});
+	done();
 }
 
 module.exports = fp(fastifyDisablecache, {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,11 +1,11 @@
-import type { FastifyPluginAsync } from "fastify";
+import type { FastifyPluginCallback } from "fastify";
 
 declare namespace fastifyDisablecache {
-	export const fastifyDisablecache: FastifyPluginAsync;
+	export const fastifyDisablecache: FastifyPluginCallback;
 	export { fastifyDisablecache as default };
 }
 
 declare function fastifyDisablecache(
-	...params: Parameters<FastifyPluginAsync>
-): ReturnType<FastifyPluginAsync>;
+	...params: Parameters<FastifyPluginCallback>
+): ReturnType<FastifyPluginCallback>;
 export = fastifyDisablecache;


### PR DESCRIPTION
BREAKING CHANGE: Plugin types changed from `FastifyPluginAsync` to `FastifyPluginCallback`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [ ] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
