### PR TITLE
perf(index): hoist `setCacheHeaders` to module scope

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,15 +11,22 @@ const CACHE_HEADERS = {
 
 /**
  * @author Frazer Smith
+ * @description Adds cache disabling headers to the response.
+ * @type {import("fastify").onRequestHookHandler}
+ */
+function setCacheHeaders(_req, res, next) {
+	res.headers(CACHE_HEADERS);
+	next();
+}
+
+/**
+ * @author Frazer Smith
  * @description Simple plugin that adds an `onRequest` hook to disable client-side caching
  * by setting the relevant response headers.
  * @type {import("fastify").FastifyPluginCallback}
  */
 function fastifyDisablecache(server, _options, done) {
-	server.addHook("onRequest", (_req, res, next) => {
-		res.headers(CACHE_HEADERS);
-		next();
-	});
+	server.addHook("onRequest", setCacheHeaders);
 	done();
 }
 


### PR DESCRIPTION
Moved the onRequest handler out of fastifyDisablecache so it’s defined once at module load, reducing setup allocations when the plugin is registered multiple times.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [ ] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
