### PR TITLE
build(dependabot): remove scope from github actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,6 @@ updates:
 
     - package-ecosystem: github-actions
       commit-message:
-          include: scope
           prefix: ci
       cooldown:
           default-days: 7


### PR DESCRIPTION
CI is CI, no need for scope of 'deps' or 'deps-dev'